### PR TITLE
include client stream (e.g. socket) in error event

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -26,7 +26,7 @@ Server.prototype.attach = function(stream) {
     var decoder = stream.pipe(FixFrameDecoder());
 
     decoder.on('error', function(err) {
-        self.emit('error', err);
+        self.emit('error', err, stream);
     });
 
     // user has 30 seconds to establish any session, otherwise they are disconnected


### PR DESCRIPTION
Without this, the server doesn't expose which client caused an error; you want to know that so you can e.g. disconnect the client.