### PR TITLE
Fixed issue with multiple FIX messages received simultaneously

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/src/frame_decoder.js
+++ b/src/frame_decoder.js
@@ -89,8 +89,9 @@ module.exports = function() {
 
             // load up proper message type
             var msg = Msg.parse(msg);
-            cb(null, msg);
+            this.push(msg);
         }
+        cb();
     });
 
     return stream;


### PR DESCRIPTION
If several FIX messages are received by the client in one chunk, "no writecb in Transform class" will be thrown by through2.

This is due to misuse of the transform function: https://github.com/rvagg/through2/issues/44

The suggested changes fix it.