### PR TITLE
Prevent multiple callbacks when buffer fills up

### DIFF
--- a/src/frame_decoder.js
+++ b/src/frame_decoder.js
@@ -88,9 +88,10 @@ module.exports = function() {
             }
 
             // load up proper message type
-            var msg = Msg.parse(msg);
-            cb(null, msg);
+            self.push(Msg.parse(msg));
         }
+
+        cb();
     });
 
     return stream;


### PR DESCRIPTION
When the buffer fills up, we would call cb() multiple times
inside the while loop. This would result in a 'no writecb in
Transform class' error, because the callback gets cleared after
transforming the state of the stream.

https://github.com/nodejs/node-v0.x-archive/blob/9e1eb361e8deb3f296a3c9d01de8fcc10361443f/lib/_stream_transform.js#L73-L106

There solution is to use through2 like in their [README](https://github.com/rvagg/through2),
where you push messages into self, and then the data event will
get fired for each of them.