### PR TITLE
Test for https://github.com/defunctzombie/fixjs/pull/7

### DIFF
--- a/test/decoder.js
+++ b/test/decoder.js
@@ -61,6 +61,29 @@ test('decode wiki example', function(done) {
     decoder.write(msg.replace(/\|/g, sep));
 });
 
+/** Test for issue fixed in commit:
+ *  https://github.com/defunctzombie/fixjs/commit/5010c720b1f3a8d71c5cda80945aa7c0bf1ba882
+ *  That prevented multiple callbacks when buffer fills up
+ */
+test('Filled up buffer', function(done) {
+    var decoder = FrameDecoder();
+    var repeat = function (string, num) {
+        return new Array(num + 1).join(string);
+    };
+    var num = 1000;
+    done = after(30, done);
+    decoder.on('data', function(msg) {
+        done();
+    });
+
+    // example messages from wikipedia page
+    // http://en.wikipedia.org/wiki/Financial_Information_eXchange
+    var msg = '8=FIX.4.2|9=178|35=8|49=PHLX|56=PERS|52=20071123-05:30:00.000|11=ATOMNOCCC9990900|20=3|150=E|39=E|55=MSFT|167=CS|54=1|38=15|40=2|44=15|58=PHLX EQUITY TESTING|59=0|47=C|32=0|31=0|151=15|14=0|6=0|10=128|';
+    var messages = repeat(msg,num);
+    decoder.write(messages.replace(/\|/g, sep));
+
+});
+
 test('invalid metadata', function(done) {
     var examples = {
         'Invalid CheckSum: ': ['8=', 'FIX.4.2', sep, '9=', '5', sep, '35=0', sep, '10=162', sep],


### PR DESCRIPTION
This test fails with https://github.com/defunctzombie/fixjs/commit/b96dba78d701ada3102f076a135f1f073a8fcf84

And passes with https://github.com/defunctzombie/fixjs/commit/5010c720b1f3a8d71c5cda80945aa7c0bf1ba882

But it seems there are some problems when running all the test files in parallel if the buffered string is too long.