### PR TITLE
src/server.js: Don't write to an ended stream.

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -100,6 +100,10 @@ Server.prototype.attach = function(stream) {
 
         // outgoing messages
         session.on('send', function(msg) {
+            if (!stream.writable) {
+                return;
+            }
+
             var out = msg.serialize();
             stream.write(out);
         });


### PR DESCRIPTION
If a stream has ended, it will be marked as not writable.

Writing to such a stream will throw an 'This socket has been
ended by the other party' error.
