### PR TITLE
Do not pass undefined or null through

### DIFF
--- a/src/msg.js
+++ b/src/msg.js
@@ -69,7 +69,8 @@ Msg.prototype.serialize = function() {
     var ignore = ['8', '9', '35', '10', '52', '49', '56', '34'];
 
     for (var tag in fields) {
-        if (fields.hasOwnProperty(tag) && ignore.indexOf(tag) === -1) {
+        if (fields.hasOwnProperty(tag) && ignore.indexOf(tag) === -1
+                && typeof fields[tag] !== 'undefined' && fields[tag] !== null) {
             body_arr.push(tag + '=' + fields[tag]);
         }
     }

--- a/test/serialize.js
+++ b/test/serialize.js
@@ -25,3 +25,26 @@ test('should not have null byte if no body', function() {
     assert.deepEqual(actual, expected);
 });
 
+test('should not pass undefined or null through', function() {
+    var msg = new Msgs.NewOrderSingle();
+
+    msg.OrderQty = undefined;
+    msg.Price = null;
+
+    var out = msg.serialize();
+
+    var expected = [
+        '8=FIX.4.2',
+        '9=57',
+        '35=D',
+        '52=undefined',
+        '49=undefined',
+        '56=undefined',
+        '34=undefined',
+        '10=082',
+	'',
+    ];
+
+    var actual = Buffer(out).toString().split('\u0001');
+    assert.deepEqual(actual, expected);
+});


### PR DESCRIPTION
Sometimes it is convenient to explicitly set a body field to be `undefined` or `null`. Consider, for example, generating an outgoing Execution Report message based on an order object whose `price` property might or might not be defined depending on whether it represents a limit or market order.